### PR TITLE
change compile target to ES5, because IE11 does not support ES classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ typings
 *.js.map
 *.d.ts
 *.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Async enabled each(), map(), filter() functions that work just like their standard counterparts, but can be used with async/await and also provide concurrency limiting. Includes built-in typings and JSDoc comments for IntelliSense documentation.",
   "main": "index.js",
   "scripts": {
+    "build": "tsc",
     "test": "mocha",
     "start": "node main.js"
   },
@@ -50,6 +51,7 @@
     "@types/mocha": "^2.2.37",
     "@types/node": "^7.0.0",
     "chai": "^3.4.1",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "typescript": "^2.8.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,10 @@
     "preserveConstEnums": false,
     "sourceMap": true,
     "declaration": true,
-    "target": "es6"
+    "target": "es5",
+    "lib": ["es2017"]
   },
   "files": [
-    "typings/tsd.d.ts",
     "index.ts",
     "main.ts",
     "test.ts"


### PR DESCRIPTION
Thanks to the awesome library, but I have issues on production when users use IE11.

`target: "es6"` is too early, I guess.